### PR TITLE
Exposed octet-vector types; added constructors

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -1,5 +1,9 @@
 (cl:defpackage :nibbles
   (:use :cl)
+  ;; Basic types and constructors.
+  (:export #:octet #:index
+           #:octet-vector #:simple-octet-vector
+           #:make-octet-vector)
   ;; Basic octet vector accessors.
   (:export #:ub16ref/le #:ub16ref/be #:sb16ref/le #:sb16ref/be
            #:ub32ref/le #:ub32ref/be #:sb32ref/le #:sb32ref/be
@@ -14,26 +18,26 @@
            #:read-ub64/le #:read-ub64/be #:read-sb64/be #:read-sb64/le)
   ;; Stream readers for vectors.
   (:export #:read-ub16/le-sequence #:read-ub16/be-sequence
-	   #:read-sb16/le-sequence #:read-sb16/be-sequence
-	   #:read-ub32/le-sequence #:read-ub32/be-sequence
-	   #:read-sb32/le-sequence #:read-sb32/be-sequence
-	   #:read-ub64/le-sequence #:read-ub64/be-sequence
-	   #:read-sb64/le-sequence #:read-sb64/be-sequence)
+           #:read-sb16/le-sequence #:read-sb16/be-sequence
+           #:read-ub32/le-sequence #:read-ub32/be-sequence
+           #:read-sb32/le-sequence #:read-sb32/be-sequence
+           #:read-ub64/le-sequence #:read-ub64/be-sequence
+           #:read-sb64/le-sequence #:read-sb64/be-sequence)
   ;; Non-consing variants akin to READ-SEQUENCE.
   (:export #:read-ub16/le-into-sequence #:read-ub16/be-into-sequence
-	   #:read-sb16/le-into-sequence #:read-sb16/be-into-sequence
-	   #:read-ub32/le-into-sequence #:read-ub32/be-into-sequence
-	   #:read-sb32/le-into-sequence #:read-sb32/be-into-sequence
-	   #:read-ub64/le-into-sequence #:read-ub64/be-into-sequence
-	   #:read-sb64/le-into-sequence #:read-sb64/be-into-sequence)
+           #:read-sb16/le-into-sequence #:read-sb16/be-into-sequence
+           #:read-ub32/le-into-sequence #:read-ub32/be-into-sequence
+           #:read-sb32/le-into-sequence #:read-sb32/be-into-sequence
+           #:read-ub64/le-into-sequence #:read-ub64/be-into-sequence
+           #:read-sb64/le-into-sequence #:read-sb64/be-into-sequence)
   ;; Stream writers.
   (:export #:write-ub16/le #:write-ub16/be #:write-sb16/be #:write-sb16/le
            #:write-ub32/le #:write-ub32/be #:write-sb32/be #:write-sb32/le
            #:write-ub64/le #:write-ub64/be #:write-sb64/be #:write-sb64/le)
   ;; Stream writers for vectors.
   (:export #:write-ub16/le-sequence #:write-ub16/be-sequence
-	   #:write-sb16/le-sequence #:write-sb16/be-sequence
-	   #:write-ub32/le-sequence #:write-ub32/be-sequence
-	   #:write-sb32/le-sequence #:write-sb32/be-sequence
-	   #:write-ub64/le-sequence #:write-ub64/be-sequence
-	   #:write-sb64/le-sequence #:write-sb64/be-sequence))
+           #:write-sb16/le-sequence #:write-sb16/be-sequence
+           #:write-ub32/le-sequence #:write-ub32/be-sequence
+           #:write-sb32/le-sequence #:write-sb32/be-sequence
+           #:write-ub64/le-sequence #:write-ub64/be-sequence
+           #:write-sb64/le-sequence #:write-sb64/be-sequence))

--- a/tests.lisp
+++ b/tests.lisp
@@ -28,7 +28,7 @@
           (t (values 0 nil))))))
 
 (defun generate-random-octet-vector (n-octets)
-  (loop with v = (make-array n-octets :element-type '(unsigned-byte 8))
+  (loop with v = (nibbles:make-octet-vector n-octets)
         for i from 0 below n-octets
         do (setf (aref v i) (random 256))
         finally (return v)))
@@ -251,7 +251,7 @@
 (defun read-file-as-octets (pathname)
   (with-open-file (stream pathname :direction :input
                           :element-type '(unsigned-byte 8))
-    (let ((v (make-array (file-length stream) :element-type '(unsigned-byte 8))))
+    (let ((v (nibbles:make-octet-vector (file-length stream))))
       (read-sequence v stream)
       v)))
 
@@ -543,145 +543,145 @@
   (write-test 'nibbles:write-sb64/le 64 t nil)
   :ok)
 
-(rtest:deftest :write-ub16/be-vector 
+(rtest:deftest :write-ub16/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub16/be-sequence
 		       'nibbles:write-ub16/be-sequence 16 nil t)
   :ok)
 
-(rtest:deftest :write-sb16/be-vector 
+(rtest:deftest :write-sb16/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb16/be-sequence
 		       'nibbles:write-sb16/be-sequence 16 t t)
   :ok)
 
-(rtest:deftest :write-ub32/be-vector 
+(rtest:deftest :write-ub32/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub32/be-sequence
 		       'nibbles:write-ub32/be-sequence 32 nil t)
   :ok)
 
-(rtest:deftest :write-sb32/be-vector 
+(rtest:deftest :write-sb32/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb32/be-sequence
 		       'nibbles:write-sb32/be-sequence 32 t t)
   :ok)
 
-(rtest:deftest :write-ub64/be-vector 
+(rtest:deftest :write-ub64/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub64/be-sequence
 		       'nibbles:write-ub64/be-sequence 64 nil t)
   :ok)
 
-(rtest:deftest :write-sb64/be-vector 
+(rtest:deftest :write-sb64/be-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb64/be-sequence
 		       'nibbles:write-sb64/be-sequence 64 t t)
   :ok)
 
-(rtest:deftest :write-ub16/le-vector 
+(rtest:deftest :write-ub16/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub16/le-sequence
 		       'nibbles:write-ub16/le-sequence 16 nil nil)
   :ok)
 
-(rtest:deftest :write-sb16/le-vector 
+(rtest:deftest :write-sb16/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb16/le-sequence
 		       'nibbles:write-sb16/le-sequence 16 t nil)
   :ok)
 
-(rtest:deftest :write-ub32/le-vector 
+(rtest:deftest :write-ub32/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub32/le-sequence
 		       'nibbles:write-ub32/le-sequence 32 nil nil)
   :ok)
 
-(rtest:deftest :write-sb32/le-vector 
+(rtest:deftest :write-sb32/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb32/le-sequence
 		       'nibbles:write-sb32/le-sequence 32 t nil)
   :ok)
 
-(rtest:deftest :write-ub64/le-vector 
+(rtest:deftest :write-ub64/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub64/le-sequence
 		       'nibbles:write-ub64/le-sequence 64 nil nil)
   :ok)
 
-(rtest:deftest :write-sb64/le-vector 
+(rtest:deftest :write-sb64/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-sb64/le-sequence
 		       'nibbles:write-sb64/le-sequence 64 t nil)
   :ok)
 
-(rtest:deftest :write-ub16/be-list 
+(rtest:deftest :write-ub16/be-list
   (write-sequence-test 'list
 		       'nibbles:read-ub16/be-sequence
 		       'nibbles:write-ub16/be-sequence 16 nil t)
   :ok)
 
-(rtest:deftest :write-sb16/be-list 
+(rtest:deftest :write-sb16/be-list
   (write-sequence-test 'list
 		       'nibbles:read-sb16/be-sequence
 		       'nibbles:write-sb16/be-sequence 16 t t)
   :ok)
 
-(rtest:deftest :write-ub32/be-list 
+(rtest:deftest :write-ub32/be-list
   (write-sequence-test 'list
 		       'nibbles:read-ub32/be-sequence
 		       'nibbles:write-ub32/be-sequence 32 nil t)
   :ok)
 
-(rtest:deftest :write-sb32/be-list 
+(rtest:deftest :write-sb32/be-list
   (write-sequence-test 'list
 		       'nibbles:read-sb32/be-sequence
 		       'nibbles:write-sb32/be-sequence 32 t t)
   :ok)
 
-(rtest:deftest :write-ub64/be-list 
+(rtest:deftest :write-ub64/be-list
   (write-sequence-test 'list
 		       'nibbles:read-ub64/be-sequence
 		       'nibbles:write-ub64/be-sequence 64 nil t)
   :ok)
 
-(rtest:deftest :write-sb64/be-list 
+(rtest:deftest :write-sb64/be-list
   (write-sequence-test 'list
 		       'nibbles:read-sb64/be-sequence
 		       'nibbles:write-sb64/be-sequence 64 t t)
   :ok)
 
-(rtest:deftest :write-ub16/le-list 
+(rtest:deftest :write-ub16/le-list
   (write-sequence-test 'list
 		       'nibbles:read-ub16/le-sequence
 		       'nibbles:write-ub16/le-sequence 16 nil nil)
   :ok)
 
-(rtest:deftest :write-sb16/le-list 
+(rtest:deftest :write-sb16/le-list
   (write-sequence-test 'list
 		       'nibbles:read-sb16/le-sequence
 		       'nibbles:write-sb16/le-sequence 16 t nil)
   :ok)
 
-(rtest:deftest :write-ub32/le-list 
+(rtest:deftest :write-ub32/le-list
   (write-sequence-test 'list
 		       'nibbles:read-ub32/le-sequence
 		       'nibbles:write-ub32/le-sequence 32 nil nil)
   :ok)
 
-(rtest:deftest :write-sb32/le-list 
+(rtest:deftest :write-sb32/le-list
   (write-sequence-test 'list
 		       'nibbles:read-sb32/le-sequence
 		       'nibbles:write-sb32/le-sequence 32 t nil)
   :ok)
 
-(rtest:deftest :write-ub64/le-list 
+(rtest:deftest :write-ub64/le-list
   (write-sequence-test 'list
 		       'nibbles:read-ub64/le-sequence
 		       'nibbles:write-ub64/le-sequence 64 nil nil)
   :ok)
 
-(rtest:deftest :write-sb64/le-list 
+(rtest:deftest :write-sb64/le-list
   (write-sequence-test 'list
 		       'nibbles:read-sb64/le-sequence
 		       'nibbles:write-sb64/le-sequence 64 t nil)

--- a/types.lisp
+++ b/types.lisp
@@ -2,11 +2,53 @@
 
 (cl:in-package :nibbles)
 
-(deftype index () '(mod #.array-dimension-limit))
+(deftype octet ()
+  '(unsigned-byte 8))
+
+(deftype index ()
+  '(mod #.array-dimension-limit))
+
+
+;;; Type `octet-vector' and constructors
+;;
 
 (deftype octet-vector (&optional (length '*))
-  `(array (unsigned-byte 8) (,length)))
+  `(array octet (,length)))
+
+(declaim (ftype (function (index
+                           &key
+                           (:initial-element octet))
+                          octet-vector)
+                make-octet-vector)
+         (inline make-octet-vector))
+
+(defun make-octet-vector (count
+                          &key
+                          (initial-element 0))
+  "Make and return an `octet-vector' with COUNT elements.
+
+If supplied, INITIAL-ELEMENT is used to populate the vector. The value
+of INITIAL-ELEMENT has to of type `octet'. "
+  (make-array count
+              :element-type    'octet
+              :initial-element initial-element))
+
+(declaim (ftype (function (&rest octet) octet-vector) octet-vector)
+         (inline octet-vector))
+
+(defun octet-vector (&rest args)
+  "Make and return an `octet-vector' containing the elements ARGS.
+ARGS have to be of type `octet'."
+  (make-array (length args)
+              :element-type     'octet
+              :initial-contents args
+              :adjustable       nil
+              :fill-pointer     nil))
+
+
+;;; Type `simple-octet-vector'
+;;
 
 (deftype simple-octet-vector (&optional (length '*))
-  #+(or sbcl cmu) `(simple-array (unsigned-byte 8) (,length))
-  #-(or sbcl cmu) `(array (unsigned-byte 8) (,length)))
+  #+(or sbcl cmu) `(simple-array octet (,length))
+  #-(or sbcl cmu) `(array octet (,length)))


### PR DESCRIPTION
See #3.

Summary:

```
Exposed octet-vector types; added constructors
* package.lisp: added exported symbols octet, index, octet-vector,
  simple-octet-vector, make-octet-vector
* types.lisp: added type octet; added functions make-octet-vector and
  octet-vector
* tests.lisp: use make-octet-vector instead of make-array where
  possible
```
