### PR TITLE
Fixed defknown errors using the :overwrite-fndb-silently keyword parameter and removed handler around system compile-op and load-op :around methods.

### DIFF
--- a/nibbles.asd
+++ b/nibbles.asd
@@ -9,15 +9,6 @@
 (defclass txt-file (asdf:doc-file) ((type :initform "txt")))
 (defclass css-file (asdf:doc-file) ((type :initform "css")))
 
-;;; Borrowed from iolib.
-(defun defknown-redefinition-error-p (error)
-  (and (typep error 'simple-error)
-       (search "overwriting old FUN-INFO"
-               (simple-condition-format-control error))))
-
-(macrolet ((do-silently (&body body)
-             `(handler-bind (((satisfies defknown-redefinition-error-p) #'continue))
-                ,@body)))
 (defmethod asdf:perform :around ((op asdf:compile-op) (c nibbles-source-file))
   (let ((*print-base* 10)               ; INTERN'ing FORMAT'd symbols
         (*print-case* :upcase)
@@ -26,7 +17,7 @@
     (do-silently (call-next-method))))
 
 (defmethod asdf:perform :around ((op asdf:load-op) (c nibbles-source-file))
-  (do-silently (call-next-method))))
+  (do-silently (call-next-method)))
 
 (asdf:defsystem :nibbles
   :version "0.12"

--- a/nibbles.asd
+++ b/nibbles.asd
@@ -14,10 +14,10 @@
         (*print-case* :upcase)
         #+sbcl (sb-ext:*inline-expansion-limit* (max sb-ext:*inline-expansion-limit* 1000))
         #+cmu (ext:*inline-expansion-limit* (max ext:*inline-expansion-limit* 1000)))
-    (do-silently (call-next-method))))
+    (call-next-method)))
 
 (defmethod asdf:perform :around ((op asdf:load-op) (c nibbles-source-file))
-  (do-silently (call-next-method)))
+  (call-next-method))
 
 (asdf:defsystem :nibbles
   :version "0.12"

--- a/nibbles.asd
+++ b/nibbles.asd
@@ -5,19 +5,8 @@
 
 (cl:in-package :nibbles-system)
 
-(defclass nibbles-source-file (asdf:cl-source-file) ())
 (defclass txt-file (asdf:doc-file) ((type :initform "txt")))
 (defclass css-file (asdf:doc-file) ((type :initform "css")))
-
-(defmethod asdf:perform :around ((op asdf:compile-op) (c nibbles-source-file))
-  (let ((*print-base* 10)               ; INTERN'ing FORMAT'd symbols
-        (*print-case* :upcase)
-        #+sbcl (sb-ext:*inline-expansion-limit* (max sb-ext:*inline-expansion-limit* 1000))
-        #+cmu (ext:*inline-expansion-limit* (max ext:*inline-expansion-limit* 1000)))
-    (call-next-method)))
-
-(defmethod asdf:perform :around ((op asdf:load-op) (c nibbles-source-file))
-  (call-next-method))
 
 (asdf:defsystem :nibbles
   :version "0.12"
@@ -25,7 +14,6 @@
   :maintainer "Nathan Froyd <froydnj@gmail.com>"
   :description "A library for accessing octet-addressed blocks of data in big- and little-endian orders"
   :license "BSD-style (http://opensource.org/licenses/BSD-3-Clause)"
-  :default-component-class nibbles-source-file
   :components ((:static-file "README")
                (:static-file "LICENSE")
                (:static-file "NEWS")

--- a/sbcl-opt/fndb.lisp
+++ b/sbcl-opt/fndb.lisp
@@ -8,7 +8,7 @@
 (sb-c:defknown %check-bound
   ((simple-array (unsigned-byte 8) (*)) index (and fixnum sb-vm:word)
    (member 2 4 8 16))
-  index)
+    index (sb-c:any) :overwrite-fndb-silently t)
 
 ;; We DEFKNOWN the exported functions so we can DEFTRANSFORM them.
 ;; We DEFKNOWN the %-functions so we can DEFINE-VOP them.
@@ -36,10 +36,10 @@
         for internal-arg-types = (subst '(simple-array (unsigned-byte 8)) 'array
                                         external-arg-types)
         collect `(sb-c:defknown (,big-fun ,little-fun) ,external-arg-types
-                     ,arg-type) into defknowns
+                     ,arg-type (sb-c:any) :overwrite-fndb-silently t) into defknowns
         collect `(sb-c:defknown (,internal-big ,internal-little)
                      ,internal-arg-types
-                     ,arg-type) into defknowns
+                     ,arg-type (sb-c:any) :overwrite-fndb-silently t) into defknowns
         finally (return `(progn ,@defknowns)))
 
 );#+sbcl


### PR DESCRIPTION
Somehow both nibbles and ironclad started not handling defknown errors when systems are loaded from Slime. Bike from freenode #lisp channel found and suggested this fix. Turns out the handler is not needed, there is a keyword parameter for that. Works like a charm for me.
